### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build_installer:
+    permissions:
+      contents: read
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jonalbr/heat-sheet-pdf-highlighter/security/code-scanning/1](https://github.com/jonalbr/heat-sheet-pdf-highlighter/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with the least necessary privileges to the `build_installer` job. In this case, only read access to repository contents is required and is the minimal recommended setting. This should be added under the `build_installer` job (after its label, before `runs-on`). No changes are needed elsewhere. No extra imports or modifications are necessary beyond editing the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
